### PR TITLE
fix(layout): preserve last character of data spec content

### DIFF
--- a/packages/layout/src/db.ts
+++ b/packages/layout/src/db.ts
@@ -70,17 +70,17 @@ function extractName(entityIdentifier: string): string | undefined {
   return entityIdentifier;
 }
 
-function stripInlineValue(dataInlineValue: string): string {
+export function stripInlineValue(dataInlineValue: string): string {
   let toHtml = dataInlineValue;
   toHtml = toHtml.substring(toHtml.indexOf('{') + 1);
-  toHtml = toHtml.substring(0, toHtml.lastIndexOf('}') - 1);
+  toHtml = toHtml.substring(0, toHtml.lastIndexOf('}'));
   return toHtml;
 }
 
-function stripBlockValue(value: string): string {
+export function stripBlockValue(value: string): string {
   let toHtml = value;
   toHtml = toHtml.substring(toHtml.indexOf('{\n') + 2);
-  toHtml = toHtml.substring(0, toHtml.lastIndexOf('}') - 1);
+  toHtml = toHtml.substring(0, toHtml.lastIndexOf('}'));
   return toHtml;
 }
 

--- a/packages/layout/test/db.test.ts
+++ b/packages/layout/test/db.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest';
+
+import { stripInlineValue, stripBlockValue } from '../src/db.js';
+
+describe('stripInlineValue', () => {
+  test('keeps the last character of an inline data spec', () => {
+    // Regression: previously `substring(0, lastIndexOf('}') - 1)` chopped
+    // the last char, so "{item, quantity}" rendered as "item, quantit".
+    expect(stripInlineValue('{item, quantity}')).toBe('item, quantity');
+  });
+
+  test('returns content verbatim for multi-field specs', () => {
+    expect(stripInlineValue('{cartId, item, quantity}')).toBe('cartId, item, quantity');
+  });
+
+  test('handles a single-character content', () => {
+    // Edge case where the off-by-one was easiest to spot: a single char
+    // body became the empty string under the old behavior.
+    expect(stripInlineValue('{x}')).toBe('x');
+  });
+
+  test('handles an empty body', () => {
+    expect(stripInlineValue('{}')).toBe('');
+  });
+
+  test('preserves leading/trailing whitespace inside the braces', () => {
+    expect(stripInlineValue('{ item, quantity }')).toBe(' item, quantity ');
+  });
+});
+
+describe('stripBlockValue', () => {
+  test('keeps the last character of a block data spec', () => {
+    // Block notation: `data Foo {\n  ...lines...\n}`. The buggy version
+    // chopped the trailing newline (and on the last line, the last char).
+    const input = '{\n  item: string\n  quantity: number\n}';
+    expect(stripBlockValue(input)).toBe('  item: string\n  quantity: number\n');
+  });
+
+  test('keeps single-line block content intact', () => {
+    expect(stripBlockValue('{\n  field: value\n}')).toBe('  field: value\n');
+  });
+});


### PR DESCRIPTION
## Summary

The two helpers in `packages/layout/src/db.ts` that strip the `{ … }` framing off data specs both used `substring(0, lastIndexOf('}') - 1)`. Since `String#substring`'s end index is already exclusive, the `- 1` chops the **last character of the content** (not the brace it was meant to remove).

Result: rendered labels lose their final character.

## Reproducer

```evml
eventmodeling

tf 01 ui CartPage {item, quantity}
tf 02 cmd AddItemToCart
tf 03 evt ItemAddedToCart {cartId, item, quantity}
```

What you see today: `item, quantit` / `cartId, item, quantit`.
What you expect: `item, quantity` / `cartId, item, quantity`.

## Math

For input `{item, quantity}` after the leading `{` is stripped, `toHtml = "item, quantity}"`:

| Expression | Value | Result |
|---|---|---|
| `lastIndexOf('}')` | 14 | (correct index of the brace) |
| **Buggy** `substring(0, 14 - 1)` | `substring(0, 13)` | `"item, quantit"` ← drops `y` |
| **Fixed** `substring(0, 14)` | `substring(0, 14)` | `"item, quantity"` ✓ |

`substring(start, end)` stops **before** index `end`, so passing `lastIndexOf('}')` already excludes the brace. The `- 1` is unconditional one-char truncation.

## In-repo precedent

`packages/layout-headless/src/drawio.ts:63,70` already has the **correct** version of these same two helpers (no `- 1`). So when `drawio.ts` was added later, the helpers were written right — this PR just brings `db.ts` in line with the in-repo precedent. Worth a follow-up refactor to share one implementation (separate PR).

## Change

- `packages/layout/src/db.ts`: removed `- 1` in two places (lines 76 and 83); exported `stripInlineValue` and `stripBlockValue` so they can be unit-tested.
- `packages/layout/test/db.test.ts` (new): 7 unit tests — inline `{…}` and block `{\n…\n}` notations, plus edge cases (single-char body, empty body, whitespace preservation). Confirmed red against the old code (6/7 fail), green with the fix (7/7 pass).

## Mermaid sibling

The exact same bug exists in the mermaid-js/mermaid port at `packages/mermaid/src/diagrams/eventmodeling/db.ts:342,356`. Happy to open a follow-up PR there once this lands, so both repos stay in sync.

## Test plan

- [x] `pnpm -F event-modeling-layout test` → 7/7 green.
- [x] Confirmed tests fail (6/7) when fix is reverted, proving regression coverage. (The one that passes either way is the empty-body `{}` case — nothing to chop.)
- [x] `pnpm -F event-modeling-layout-headless test` → 8/8 green (no downstream regression).
- [x] `pnpm -F event-modeling-language test` → 26/26 green (unrelated, sanity).

🤖 Drafted with Claude Code; reviewed and pushed by @IvanTheGeek.